### PR TITLE
Add Docker configuration for app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.gitignore
+vendor
+var
+node_modules
+.dockerignore
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM php:8.3-cli
+
+# Install system dependencies and PHP extensions
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git unzip libpq-dev \
+    && docker-php-ext-install pdo pdo_pgsql \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+WORKDIR /app
+
+# Copy application files
+COPY . /app
+
+# Install PHP dependencies
+RUN composer install --no-interaction --prefer-dist --optimize-autoloader
+
+# Expose port for the built-in server
+EXPOSE 8000
+
+# Start the Symfony application using PHP's built-in web server
+CMD ["php", "-S", "0.0.0.0:8000", "-t", "public"]

--- a/README.md
+++ b/README.md
@@ -18,3 +18,12 @@ symfony server:start
 
 Then browse the API at `http://localhost:8000/api`.
 
+## Docker
+
+Build and start the application with Docker:
+
+```bash
+docker-compose up --build
+```
+
+The API will be available at `http://localhost:8000/api`. To run additional commands inside the container, use `docker-compose exec app <command>`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3.8'
+
+services:
+  app:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      APP_ENV: dev
+      APP_SECRET: change_me
+      DATABASE_URL: "postgresql://app:change_me@db:5432/app?serverVersion=16&charset=utf8"
+    volumes:
+      - .:/app
+    depends_on:
+      - db
+
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: app
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: change_me
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary
- add Dockerfile with Composer and PostgreSQL support
- define docker-compose services for app and database
- document Docker usage in README

## Testing
- `composer validate --no-check-lock`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68accd7ea40c83328387a56ceb44881e